### PR TITLE
Server and client queueing/throttling support

### DIFF
--- a/CodeLLamaDirectServer.py
+++ b/CodeLLamaDirectServer.py
@@ -54,7 +54,7 @@ class CodeLLamaDirectServer(IKnowledgeServer):
                 inSystem+=1
 
     def Submit(self, request : DiffRequest, context):
-        super().Submit(request, context)
+        res = super().Submit(request, context)
         if self._single_generator:
             generator = copy.deepcopy(self._single_generator)
             results = generator.chat_completion(
@@ -65,9 +65,11 @@ class CodeLLamaDirectServer(IKnowledgeServer):
             )
             generator = None
             logging.info(f"Result -> {results}")
-            return DiffResult(Result=[result['generation']['content'] for result in results])
+            res.Result = [result['generation']['content'] for result in results]
+            return res
         else:
-            return DiffResult(Result=[])
+            res.Result = []
+            return res
 
     def Shutdown(self, request, context):
         self._single_generator = None

--- a/CodeLLamaDirectServer.py
+++ b/CodeLLamaDirectServer.py
@@ -53,23 +53,17 @@ class CodeLLamaDirectServer(IKnowledgeServer):
             else:
                 inSystem+=1
 
-    def Submit(self, request : DiffRequest, context):
-        res = super().Submit(request, context)
+    def _Submit(self, diff_request : DiffRequest, diff_result : DiffResult) -> None:
         if self._single_generator:
             generator = copy.deepcopy(self._single_generator)
             results = generator.chat_completion(
-                list(self.ConvertPromptsToInstructions(request)),
+                list(self.ConvertPromptsToInstructions(diff_request)),
                 max_gen_len=self.DEFAULT_GEN_LEN,
                 temperature=self.Temperature(),
                 top_p=self.DEFAULT_THRESHOLD
             )
             generator = None
-            logging.info(f"Result -> {results}")
-            res.Result = [result['generation']['content'] for result in results]
-            return res
-        else:
-            res.Result = []
-            return res
+            diff_result.Result.extend([result['generation']['content'] for result in results])
 
     def Shutdown(self, request, context):
         self._single_generator = None

--- a/IKnowledgeServer.py
+++ b/IKnowledgeServer.py
@@ -46,6 +46,7 @@ class IKnowledgeServer(server_pb2_grpc.PeachyServerServicer):
         qstruct = self.q.TryQueue(request)
         res = qstruct[1]
         if qstruct[0]: #if can run immediately, run it now
+            #TODO this isn't working on queued client, returns no response
             try:
                 self._Submit(request, res)
             finally:

--- a/IKnowledgeServer.py
+++ b/IKnowledgeServer.py
@@ -45,7 +45,7 @@ class IKnowledgeServer(server_pb2_grpc.PeachyServerServicer):
         logging.info(f"Recieved Prompt (IsStatusCheck->{request.IsStatusCheck()}): {str(request)}")
         qstruct = self.q.TryQueue(request)
         res = qstruct[1]
-        if not qstruct[0]: #if can run immediately, run it now
+        if qstruct[0]: #if can run immediately, run it now
             try:
                 self._Submit(request, res)
             finally:

--- a/IKnowledgeServer.py
+++ b/IKnowledgeServer.py
@@ -46,9 +46,8 @@ class IKnowledgeServer(server_pb2_grpc.PeachyServerServicer):
         qstruct = self.q.TryQueue(request)
         res = qstruct[1]
         if qstruct[0]: #if can run immediately, run it now
-            #TODO this isn't working on queued client, returns no response
             try:
-                self._Submit(request, res)
+                self._Submit(qstruct[0], res)
             finally:
                 self.q.RemoveQueued(res.ResultID)
         logging.info(f"Result -> {res}")

--- a/IKnowledgeServer.py
+++ b/IKnowledgeServer.py
@@ -1,9 +1,10 @@
 import io
 import subprocess
 import logging
+import uuid
 import server_pb2_grpc
 import server_pb2
-from server_pb2 import PromptType, DiffRequest, Empty
+from server_pb2 import PromptType, ResponseType ,DiffRequest, DiffResult, Empty
 from ServerCommon import ServerParams
 
 """
@@ -35,9 +36,9 @@ class IKnowledgeServer(server_pb2_grpc.PeachyServerServicer):
         else:
             return "user"
     
-    def Submit(self, request : DiffRequest, context):
+    def Submit(self, request : DiffRequest, context) -> DiffResult:
         logging.info(f"Recieved Prompt: {str(request)}")
-        return None
+        return DiffResult(ResultID=uuid.uuid4(), ResultType=ResponseType.ResponseType_COMPLETE)
     
     def ChangeSettings(self, request : server_pb2.Settings, context):
         logging.info(f"Caught change in settings -> {request}")

--- a/IKnowledgeServer.py
+++ b/IKnowledgeServer.py
@@ -37,7 +37,7 @@ class IKnowledgeServer(server_pb2_grpc.PeachyServerServicer):
             return "user"
     
     def _Submit(self, request : DiffRequest, result : DiffResult) -> None:
-        raise NotImplementedError("_submit is an abstract method")
+        raise NotImplementedError("_Submit is an abstract method")
 
     def Submit(self, request : DiffRequest, context) -> DiffResult:
         logging.info(f"Recieved Prompt: {str(request)}")

--- a/IKnowledgeServer.py
+++ b/IKnowledgeServer.py
@@ -45,8 +45,11 @@ class IKnowledgeServer(server_pb2_grpc.PeachyServerServicer):
         logging.info(f"Recieved Prompt (IsStatusCheck->{request.IsStatusCheck()}): {str(request)}")
         qstruct = self.q.TryQueue(request)
         res = qstruct[1]
-        if not qstruct[0]: #if not queued, run it now
-            self._Submit(request, res)
+        if not qstruct[0]: #if can run immediately, run it now
+            try:
+                self._Submit(request, res)
+            finally:
+                self.q.RemoveQueued(res.ResultID)
         logging.info(f"Result -> {res}")
         return res
 

--- a/IKnowledgeServer.py
+++ b/IKnowledgeServer.py
@@ -36,10 +36,16 @@ class IKnowledgeServer(server_pb2_grpc.PeachyServerServicer):
         else:
             return "user"
     
+    def _Submit(self, request : DiffRequest, result : DiffResult) -> None:
+        raise NotImplementedError("_submit is an abstract method")
+
     def Submit(self, request : DiffRequest, context) -> DiffResult:
         logging.info(f"Recieved Prompt: {str(request)}")
-        return DiffResult(ResultID=uuid.uuid4(), ResultType=ResponseType.ResponseType_COMPLETE)
-    
+        res = DiffResult(ResultID=str(uuid.uuid4()), ResultType=ResponseType.ResponseType_COMPLETE)
+        self._Submit(request, res)
+        logging.info(f"Result -> {res}")
+        return res
+
     def ChangeSettings(self, request : server_pb2.Settings, context):
         logging.info(f"Caught change in settings -> {request}")
         self.settings.TEMPERATURE = request.Temperature

--- a/IOLLamaServer.py
+++ b/IOLLamaServer.py
@@ -31,7 +31,6 @@ class IOLLamaServer(IKnowledgeServer.IKnowledgeServer):
 
     @staticmethod
     def assertResponse(res):
-        print(res.text)
         resDict = IOLLamaServer.fromJSON(res.text)
         if (not IOLLamaServer.CONST_VALID_DONE in resDict) or (not resDict[IOLLamaServer.CONST_VALID_DONE]):
             raise Exception(f"Ollama response invalid -> '{res.text}'")     

--- a/IOLLamaServer.py
+++ b/IOLLamaServer.py
@@ -67,7 +67,8 @@ class IOLLamaServer(IKnowledgeServer.IKnowledgeServer):
         return IOLLamaServer.toJSON(s)
 
     def Submit(self, request : DiffRequest, context):
-        super().Submit(request, context)
+        dres = super().Submit(request, context)
         res = IOLLamaServer.assertResponse(requests.post(url=self.getGenerateUrl(), data=self.makeRequest(request)))
         logging.info(f"Result -> {res}")
-        return DiffResult(Result=[res['response']])
+        dres.Result = [res['response']]
+        return dres

--- a/IOLLamaServer.py
+++ b/IOLLamaServer.py
@@ -66,9 +66,6 @@ class IOLLamaServer(IKnowledgeServer.IKnowledgeServer):
         s = self._makeRequest(request)
         return IOLLamaServer.toJSON(s)
 
-    def Submit(self, request : DiffRequest, context):
-        dres = super().Submit(request, context)
-        res = IOLLamaServer.assertResponse(requests.post(url=self.getGenerateUrl(), data=self.makeRequest(request)))
-        logging.info(f"Result -> {res}")
-        dres.Result = [res['response']]
-        return dres
+    def _Submit(self, diff_request : DiffRequest, diff_result : DiffResult):
+        res = IOLLamaServer.assertResponse(requests.post(url=self.getGenerateUrl(), data=self.makeRequest(diff_request)))
+        diff_result.Result.extend([res['response']])

--- a/KnowledgeServerQueue.py
+++ b/KnowledgeServerQueue.py
@@ -1,0 +1,40 @@
+import threading
+import uuid
+from collections import deque
+from server_pb2 import DiffRequest, DiffResult, ResponseType
+import server_pb2_pyi_extensions
+from dataclasses import dataclass
+
+@dataclass
+class QueueItem:
+    Request : DiffRequest
+    Result : DiffResult
+
+class KnowledgeServerQueue:
+    def __init__(self, queue_size : int):
+        self.size = queue_size
+        self.lock = threading.Lock()
+        self.q = deque()
+        self.running = 0
+
+    def shouldQueue(self):
+        return self.running >= self.size
+    
+    def checkStatus(self, id : str):
+        f = filter(lambda e: e.Result and e.Result.ResultID == id, self.q)
+        try:
+            return next(f)
+        except StopIteration:
+            return None
+
+    def TryQueue(self, request : DiffRequest, response : DiffResult = None):
+        with self.lock:
+            if request.IsCheckStatus() and :
+                
+            if self.shouldQueue():
+                response = DiffResult(ResultID=str(uuid.uuid4()), ResultType=ResponseType.ResponseType_COMPLETE)
+
+    def RecordCompletion(self, isQueued : bool):
+        if isQueued:
+            with self.lock:
+                self.running = self.running - 1

--- a/KnowledgeServerQueue.py
+++ b/KnowledgeServerQueue.py
@@ -49,6 +49,7 @@ class KnowledgeServerQueue:
                     if self.canRun():
                         logging.info("QUEUE: canRun on isQueued on IsStatusCheck")
                         self.running_count = self.running_count + 1
+                        #TODO if we are going to run a queued request, we need to pull the request back off the queue. It works below becasue the caller still has the prompt request
                         return (True, KnowledgeServerQueue.initResult(id=request.ResultID))
                     else:
                         logging.info("QUEUE: not canRun on isQueued on IsStatusCheck")

--- a/KnowledgeServerQueue.py
+++ b/KnowledgeServerQueue.py
@@ -2,12 +2,6 @@ import threading
 import uuid
 from server_pb2 import DiffRequest, DiffResult, ResponseType
 import server_pb2_pyi_extensions
-from dataclasses import dataclass
-
-#@dataclass
-#class QueueItem:
-#    Request : DiffRequest
-#    Result : DiffResult
 
 class KnowledgeServerQueue:
     def __init__(self, queue_size : int):

--- a/KnowledgeServerQueue.py
+++ b/KnowledgeServerQueue.py
@@ -49,23 +49,20 @@ class KnowledgeServerQueue:
                     if self.canRun():
                         logging.info("QUEUE: canRun on isQueued on IsStatusCheck")
                         self.running_count = self.running_count + 1
-                        #TODO if we are going to run a queued request, we need to pull the request back off the queue. It works below becasue the caller still has the prompt request
-                        return (True, KnowledgeServerQueue.initResult(id=request.ResultID))
+                        return (self.q[request.ResultID], KnowledgeServerQueue.initResult(id=request.ResultID))
                     else:
                         logging.info("QUEUE: not canRun on isQueued on IsStatusCheck")
-                        e = self.q[request.ResultID]
-                        return (False, KnowledgeServerQueue.initResult(id=request.ResultID, t = ResponseType.ResponseType_QUEUED))
+                        return (None, KnowledgeServerQueue.initResult(id=request.ResultID, t = ResponseType.ResponseType_QUEUED))
                 else:
                     logging.info("QUEUE: not id queued on IsStatusCheck")
-                    #this should not impact running_count and COULD be an exception
-                    return (True, KnowledgeServerQueue.initResult(id=request.ResultID))
+                    raise Exception(f"Unknown ResultID {request.ResultID}")
             else:
                 logging.info("QUEUE: not IsStatusCheck")
                 if self.canRun():
                     logging.info("QUEUE: canRun")
                     tmpres = self.queueIt(request)
                     self.running_count = self.running_count + 1
-                    return(True, KnowledgeServerQueue.initResult(id=tmpres.ResultID))
+                    return(request, KnowledgeServerQueue.initResult(id=tmpres.ResultID))
                 else:
                     logging.info("QUEUE: not canRun -> queued")
-                    return (False,self.queueIt(request))
+                    return (None,self.queueIt(request))

--- a/KnowledgeServerQueue.py
+++ b/KnowledgeServerQueue.py
@@ -16,7 +16,7 @@ class KnowledgeServerQueue:
         self.q = {}
 
     def canRun(self):
-        return len(self.q.items) < self.size
+        return len(self.q) < self.size
     
     def isQueued(self, id : str) -> bool:
         return id in self.q

--- a/KnowledgeServerQueue.py
+++ b/KnowledgeServerQueue.py
@@ -1,5 +1,6 @@
 import threading
 import uuid
+import logging
 from server_pb2 import DiffRequest, DiffResult, ResponseType
 import server_pb2_pyi_extensions
 
@@ -14,8 +15,13 @@ class KnowledgeServerQueue:
     
     def isQueued(self, id : str) -> bool:
         return id in self.q
-    def removeQueued(self, id :str):
-        del self.q[id]
+    
+    def _removeQueued(self, id :str):
+        self.q.pop(id, None)
+
+    def RemoveQueued(self, id : str):
+        with self.lock:
+            self._removeQueued(id)
 
     @staticmethod
     def _newID() -> str:
@@ -35,17 +41,26 @@ class KnowledgeServerQueue:
     def TryQueue(self, request : DiffRequest):
         with self.lock:
             if request.IsStatusCheck():
+                logging.info("QUEUE: IsStatusCheck")
                 if self.isQueued(request.ResultID):
+                    logging.info("QUEUE: isQueued on IsStatusCheck")
                     if self.canRun():
-                        self.removeQueued(request.ResultID)
+                        logging.info("QUEUE: canRun on isQueued on IsStatusCheck")
+                        self._removeQueued(request.ResultID)
                         return (False, KnowledgeServerQueue.initResult(id=request.ResultID))
                     else:
+                        logging.info("QUEUE: not canRun on isQueued on IsStatusCheck")
                         e = self.q[request.ResultID]
                         return (True, KnowledgeServerQueue.initResult(id=request.ResultID, t = ResponseType.ResponseType_QUEUED))
                 else:
+                    logging.info("QUEUE: not id queued on IsStatusCheck")
                     return (False, KnowledgeServerQueue.initResult(id=request.ResultID))
             else:
+                logging.info("QUEUE: not IsStatusCheck")
                 if self.canRun():
-                    return(False, KnowledgeServerQueue.initResult())
+                    logging.info("QUEUE: canRun")
+                    tmpres = self.queueIt(request)
+                    return(False, KnowledgeServerQueue.initResult(id=tmpres.ResultID))
                 else:
+                    logging.info("QUEUE: not canRun -> queued")
                     return (True,self.queueIt(request))

--- a/PeachyCodeClient.py
+++ b/PeachyCodeClient.py
@@ -5,9 +5,10 @@ import argparse
 import grpc
 import logging
 import datetime
+import time
 from timeit import default_timer as timer
 from server_pb2_grpc import PeachyServerStub 
-from server_pb2 import DiffRequest, DiffResult, PromptItem, PromptType, Settings
+from server_pb2 import DiffRequest, DiffResult, PromptItem, PromptType, Settings, ResponseType
 import server_pb2_pyi_extensions
 from ServerCommon import LISTEN_IF_PORT
 
@@ -61,13 +62,24 @@ def rpccall_ChangeTemperature(ip : str, newTemp : float):
         settingsChange = Settings(Temperature=newTemp)
         proxy.ChangeSettings(settingsChange)
 
+def handleQueueItem(proxy : PeachyServerStub, prompt : DiffRequest) -> DiffResult:
+    tryp = prompt
+    while True:
+        result : DiffResult = proxy.Submit( tryp )
+        if result.ResultType == ResponseType.ResponseType_QUEUED:
+            tryp = DiffRequest(ResultID=result.ResultID)
+            print('.', end = '')
+            logging.info('Polling request...')
+            time.sleep(1.0)
+        else:
+            return result
+
 def rpccall_Prompt(prompt : DiffRequest, ip : str) -> DiffResult:
     with rpccall_address(ip) as channel:
         proxy = PeachyServerStub(channel)
         print(f"Sending to {ip}: {prompt}")
-        logging.info("REQUEST -> " + str(prompt) + "\n")
-        result : DiffResult = proxy.Submit( prompt )
-        return result
+        logging.info("REQUEST -> " + str(prompt) + "\n")    
+        return handleQueueItem(proxy, prompt)
 
 def read_stdin():
     out = []

--- a/PeachyCodeClient.py
+++ b/PeachyCodeClient.py
@@ -64,14 +64,18 @@ def rpccall_ChangeTemperature(ip : str, newTemp : float):
 
 def handleQueueItem(proxy : PeachyServerStub, prompt : DiffRequest) -> DiffResult:
     tryp = prompt
+    did_wait = False
     while True:
         result : DiffResult = proxy.Submit( tryp )
         if result.ResultType == ResponseType.ResponseType_QUEUED:
             tryp = DiffRequest(ResultID=result.ResultID)
             print('.', end = '')
-            logging.info('Polling request...')
+            logging.info(f'Request {result.ResultID} queued awaiting execution...')
             time.sleep(1.0)
+            did_wait = True
         else:
+            if did_wait:
+                print(".")
             return result
 
 def rpccall_Prompt(prompt : DiffRequest, ip : str) -> DiffResult:

--- a/server.proto
+++ b/server.proto
@@ -12,9 +12,16 @@ service PeachyServer {
     rpc ChangeSettings(Settings) returns (Empty);
 }
 
+//The type of prompt being system or user
 enum PromptType {
     PromptType_USER = 0;
     PromptType_SYSTEM = 1;
+}
+
+//The type of response being completed or queued
+enum ResponseType {
+    ResponseType_COMPLETE = 0;
+    ResponseType_QUEUED = 1;
 }
 
 //The Prompt item (prompt type and string value)
@@ -29,12 +36,18 @@ message PromptItem {
 message DiffRequest {
     //Request prompt string
     repeated PromptItem Request=1;
+    //The unique result id returned by DiffResult in order to check the status of a queued request
+    string ResultID=2;
 }
 
 //The Response message
 message DiffResult {
     //String array result
     repeated string Result=1;
+    //Enum indicating the type of response
+    ResponseType ResultType=2;
+    //The unique result id for this request, can be used in the case of a queued request to check its status
+    string ResultID=3;
 }
 
 //Settings message for changing the server settings from the client

--- a/server_pb2.py
+++ b/server_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cserver.proto\"7\n\nPromptItem\x12\x19\n\x04Type\x18\x01 \x01(\x0e\x32\x0b.PromptType\x12\x0e\n\x06Prompt\x18\x02 \x01(\t\"=\n\x0b\x44iffRequest\x12\x1c\n\x07Request\x18\x01 \x03(\x0b\x32\x0b.PromptItem\x12\x10\n\x08ResultID\x18\x02 \x01(\t\"Q\n\nDiffResult\x12\x0e\n\x06Result\x18\x01 \x03(\t\x12!\n\nResultType\x18\x02 \x01(\x0e\x32\r.ResponseType\x12\x10\n\x08ResultID\x18\x03 \x01(\t\"\x1f\n\x08Settings\x12\x13\n\x0bTemperature\x18\x01 \x01(\x02\"\x07\n\x05\x45mpty*8\n\nPromptType\x12\x13\n\x0fPromptType_USER\x10\x00\x12\x15\n\x11PromptType_SYSTEM\x10\x01*B\n\x0cResponseType\x12\x19\n\x15ResponseType_COMPLETE\x10\x00\x12\x17\n\x13ResponseType_QUEUED\x10\x01\x32\x9b\x01\n\x0cPeachyServer\x12#\n\x06Submit\x12\x0c.DiffRequest\x1a\x0b.DiffResult\x12%\n\x08GPUStats\x12\x0c.DiffRequest\x1a\x0b.DiffResult\x12\x1a\n\x08Shutdown\x12\x06.Empty\x1a\x06.Empty\x12#\n\x0e\x43hangeSettings\x12\t.Settings\x1a\x06.Emptyb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cserver.proto\"7\n\nPromptItem\x12\x19\n\x04Type\x18\x01 \x01(\x0e\x32\x0b.PromptType\x12\x0e\n\x06Prompt\x18\x02 \x01(\t\"=\n\x0b\x44iffRequest\x12\x1c\n\x07Request\x18\x01 \x03(\x0b\x32\x0b.PromptItem\x12\x10\n\x08ResultID\x18\x02 \x01(\t\"Q\n\nDiffResult\x12\x0e\n\x06Result\x18\x01 \x03(\t\x12!\n\nResultType\x18\x02 \x01(\x0e\x32\r.ResponseType\x12\x10\n\x08ResultID\x18\x03 \x01(\t\"\x1f\n\x08Settings\x12\x13\n\x0bTemperature\x18\x01 \x01(\x02\"\x07\n\x05\x45mpty*8\n\nPromptType\x12\x13\n\x0fPromptType_USER\x10\x00\x12\x15\n\x11PromptType_SYSTEM\x10\x01*\\\n\x0cResponseType\x12\x19\n\x15ResponseType_COMPLETE\x10\x00\x12\x17\n\x13ResponseType_QUEUED\x10\x01\x12\x18\n\x14ResponseType_RUNNING\x10\x02\x32\x9b\x01\n\x0cPeachyServer\x12#\n\x06Submit\x12\x0c.DiffRequest\x1a\x0b.DiffResult\x12%\n\x08GPUStats\x12\x0c.DiffRequest\x1a\x0b.DiffResult\x12\x1a\n\x08Shutdown\x12\x06.Empty\x1a\x06.Empty\x12#\n\x0e\x43hangeSettings\x12\t.Settings\x1a\x06.Emptyb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -24,7 +24,7 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _globals['_PROMPTTYPE']._serialized_start=261
   _globals['_PROMPTTYPE']._serialized_end=317
   _globals['_RESPONSETYPE']._serialized_start=319
-  _globals['_RESPONSETYPE']._serialized_end=385
+  _globals['_RESPONSETYPE']._serialized_end=411
   _globals['_PROMPTITEM']._serialized_start=16
   _globals['_PROMPTITEM']._serialized_end=71
   _globals['_DIFFREQUEST']._serialized_start=73
@@ -35,6 +35,6 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _globals['_SETTINGS']._serialized_end=250
   _globals['_EMPTY']._serialized_start=252
   _globals['_EMPTY']._serialized_end=259
-  _globals['_PEACHYSERVER']._serialized_start=388
-  _globals['_PEACHYSERVER']._serialized_end=543
+  _globals['_PEACHYSERVER']._serialized_start=414
+  _globals['_PEACHYSERVER']._serialized_end=569
 # @@protoc_insertion_point(module_scope)

--- a/server_pb2.py
+++ b/server_pb2.py
@@ -14,25 +14,27 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cserver.proto\"7\n\nPromptItem\x12\x19\n\x04Type\x18\x01 \x01(\x0e\x32\x0b.PromptType\x12\x0e\n\x06Prompt\x18\x02 \x01(\t\"+\n\x0b\x44iffRequest\x12\x1c\n\x07Request\x18\x01 \x03(\x0b\x32\x0b.PromptItem\"\x1c\n\nDiffResult\x12\x0e\n\x06Result\x18\x01 \x03(\t\"\x1f\n\x08Settings\x12\x13\n\x0bTemperature\x18\x01 \x01(\x02\"\x07\n\x05\x45mpty*8\n\nPromptType\x12\x13\n\x0fPromptType_USER\x10\x00\x12\x15\n\x11PromptType_SYSTEM\x10\x01\x32\x9b\x01\n\x0cPeachyServer\x12#\n\x06Submit\x12\x0c.DiffRequest\x1a\x0b.DiffResult\x12%\n\x08GPUStats\x12\x0c.DiffRequest\x1a\x0b.DiffResult\x12\x1a\n\x08Shutdown\x12\x06.Empty\x1a\x06.Empty\x12#\n\x0e\x43hangeSettings\x12\t.Settings\x1a\x06.Emptyb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cserver.proto\"7\n\nPromptItem\x12\x19\n\x04Type\x18\x01 \x01(\x0e\x32\x0b.PromptType\x12\x0e\n\x06Prompt\x18\x02 \x01(\t\"=\n\x0b\x44iffRequest\x12\x1c\n\x07Request\x18\x01 \x03(\x0b\x32\x0b.PromptItem\x12\x10\n\x08ResultID\x18\x02 \x01(\t\"Q\n\nDiffResult\x12\x0e\n\x06Result\x18\x01 \x03(\t\x12!\n\nResultType\x18\x02 \x01(\x0e\x32\r.ResponseType\x12\x10\n\x08ResultID\x18\x03 \x01(\t\"\x1f\n\x08Settings\x12\x13\n\x0bTemperature\x18\x01 \x01(\x02\"\x07\n\x05\x45mpty*8\n\nPromptType\x12\x13\n\x0fPromptType_USER\x10\x00\x12\x15\n\x11PromptType_SYSTEM\x10\x01*B\n\x0cResponseType\x12\x19\n\x15ResponseType_COMPLETE\x10\x00\x12\x17\n\x13ResponseType_QUEUED\x10\x01\x32\x9b\x01\n\x0cPeachyServer\x12#\n\x06Submit\x12\x0c.DiffRequest\x1a\x0b.DiffResult\x12%\n\x08GPUStats\x12\x0c.DiffRequest\x1a\x0b.DiffResult\x12\x1a\n\x08Shutdown\x12\x06.Empty\x1a\x06.Empty\x12#\n\x0e\x43hangeSettings\x12\t.Settings\x1a\x06.Emptyb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'server_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
   DESCRIPTOR._options = None
-  _globals['_PROMPTTYPE']._serialized_start=190
-  _globals['_PROMPTTYPE']._serialized_end=246
+  _globals['_PROMPTTYPE']._serialized_start=261
+  _globals['_PROMPTTYPE']._serialized_end=317
+  _globals['_RESPONSETYPE']._serialized_start=319
+  _globals['_RESPONSETYPE']._serialized_end=385
   _globals['_PROMPTITEM']._serialized_start=16
   _globals['_PROMPTITEM']._serialized_end=71
   _globals['_DIFFREQUEST']._serialized_start=73
-  _globals['_DIFFREQUEST']._serialized_end=116
-  _globals['_DIFFRESULT']._serialized_start=118
-  _globals['_DIFFRESULT']._serialized_end=146
-  _globals['_SETTINGS']._serialized_start=148
-  _globals['_SETTINGS']._serialized_end=179
-  _globals['_EMPTY']._serialized_start=181
-  _globals['_EMPTY']._serialized_end=188
-  _globals['_PEACHYSERVER']._serialized_start=249
-  _globals['_PEACHYSERVER']._serialized_end=404
+  _globals['_DIFFREQUEST']._serialized_end=134
+  _globals['_DIFFRESULT']._serialized_start=136
+  _globals['_DIFFRESULT']._serialized_end=217
+  _globals['_SETTINGS']._serialized_start=219
+  _globals['_SETTINGS']._serialized_end=250
+  _globals['_EMPTY']._serialized_start=252
+  _globals['_EMPTY']._serialized_end=259
+  _globals['_PEACHYSERVER']._serialized_start=388
+  _globals['_PEACHYSERVER']._serialized_end=543
 # @@protoc_insertion_point(module_scope)

--- a/server_pb2.pyi
+++ b/server_pb2.pyi
@@ -10,8 +10,15 @@ class PromptType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
     __slots__ = ()
     PromptType_USER: _ClassVar[PromptType]
     PromptType_SYSTEM: _ClassVar[PromptType]
+
+class ResponseType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    ResponseType_COMPLETE: _ClassVar[ResponseType]
+    ResponseType_QUEUED: _ClassVar[ResponseType]
 PromptType_USER: PromptType
 PromptType_SYSTEM: PromptType
+ResponseType_COMPLETE: ResponseType
+ResponseType_QUEUED: ResponseType
 
 class PromptItem(_message.Message):
     __slots__ = ("Type", "Prompt")
@@ -22,16 +29,22 @@ class PromptItem(_message.Message):
     def __init__(self, Type: _Optional[_Union[PromptType, str]] = ..., Prompt: _Optional[str] = ...) -> None: ...
 
 class DiffRequest(_message.Message):
-    __slots__ = ("Request",)
+    __slots__ = ("Request", "ResultID")
     REQUEST_FIELD_NUMBER: _ClassVar[int]
+    RESULTID_FIELD_NUMBER: _ClassVar[int]
     Request: _containers.RepeatedCompositeFieldContainer[PromptItem]
-    def __init__(self, Request: _Optional[_Iterable[_Union[PromptItem, _Mapping]]] = ...) -> None: ...
+    ResultID: str
+    def __init__(self, Request: _Optional[_Iterable[_Union[PromptItem, _Mapping]]] = ..., ResultID: _Optional[str] = ...) -> None: ...
 
 class DiffResult(_message.Message):
-    __slots__ = ("Result",)
+    __slots__ = ("Result", "ResultType", "ResultID")
     RESULT_FIELD_NUMBER: _ClassVar[int]
+    RESULTTYPE_FIELD_NUMBER: _ClassVar[int]
+    RESULTID_FIELD_NUMBER: _ClassVar[int]
     Result: _containers.RepeatedScalarFieldContainer[str]
-    def __init__(self, Result: _Optional[_Iterable[str]] = ...) -> None: ...
+    ResultType: ResponseType
+    ResultID: str
+    def __init__(self, Result: _Optional[_Iterable[str]] = ..., ResultType: _Optional[_Union[ResponseType, str]] = ..., ResultID: _Optional[str] = ...) -> None: ...
 
 class Settings(_message.Message):
     __slots__ = ("Temperature",)

--- a/server_pb2.pyi
+++ b/server_pb2.pyi
@@ -15,10 +15,12 @@ class ResponseType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
     __slots__ = ()
     ResponseType_COMPLETE: _ClassVar[ResponseType]
     ResponseType_QUEUED: _ClassVar[ResponseType]
+    ResponseType_RUNNING: _ClassVar[ResponseType]
 PromptType_USER: PromptType
 PromptType_SYSTEM: PromptType
 ResponseType_COMPLETE: ResponseType
 ResponseType_QUEUED: ResponseType
+ResponseType_RUNNING: ResponseType
 
 class PromptItem(_message.Message):
     __slots__ = ("Type", "Prompt")

--- a/server_pb2_pyi_extensions.py
+++ b/server_pb2_pyi_extensions.py
@@ -1,4 +1,5 @@
 from server_pb2 import PromptItem, PromptType , DiffRequest, DiffResult
 PromptItem.__str__ = lambda self : f"{PromptType.Name(self.Type)} -> {self.Prompt.rstrip()}"
 DiffRequest.__str__ = lambda self :  "\n**BEGIN**" + "\n".join( map(lambda i: str(i), self.Request)) + "**END**\n"
+DiffRequest.IsCheckStatus = lambda self: len(self.Request) == 0 and self.ResultID
 DiffResult.__str__ = lambda self : "".join(self.Result)

--- a/server_pb2_pyi_extensions.py
+++ b/server_pb2_pyi_extensions.py
@@ -1,5 +1,5 @@
 from server_pb2 import PromptItem, PromptType , DiffRequest, DiffResult
 PromptItem.__str__ = lambda self : f"{PromptType.Name(self.Type)} -> {self.Prompt.rstrip()}"
 DiffRequest.__str__ = lambda self :  "\n**BEGIN**" + "\n".join( map(lambda i: str(i), self.Request)) + "**END**\n"
-DiffRequest.IsCheckStatus = lambda self: len(self.Request) == 0 and self.ResultID
+DiffRequest.IsStatusCheck = lambda self: len(self.Request) == 0 and self.ResultID
 DiffResult.__str__ = lambda self : "".join(self.Result)


### PR DESCRIPTION
The server throttles to a maximum number of concurrent prompt executions. Prompts submitted after that get their requests queued and a ResultID assigned. It is then up to the client to continue to poll for the completion of that request. To support this, a ResponseType enum was added to the DiffResult struct. The poll request is simply a DiffRequest without a prompt and a filled in ResultID (obtained from the initial submission result which returns immediately). Since each gRPC request is its own thread anyway, gRPC handles the conconcurrency for us basically. No need for a worker thread on the server or anything. The queuing mechanism is a simple dict that is protected with a lock. End result: submit as much as you want to the server. Requests may have to wait. Once they are executing the client will block waiting the final result. The client cooperates in "caring" and driving the threading. If a client ceases to care by stopping polling, the request will be orphaned in the server (ya tiny memory leak).